### PR TITLE
Set up Ghostty config file replacing tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Personal configuration files for macOS, optimized for DevOps and cloud engineeri
 
 - **`.zshrc`** - Zsh shell configuration with Oh My Zsh framework
 - **`.tmux.conf`** - Tmux terminal multiplexer configuration
+- **`ghostty/config`** - Ghostty terminal emulator configuration (tmux alternative)
 
 ## Features
 
@@ -52,6 +53,25 @@ Personal configuration files for macOS, optimized for DevOps and cloud engineeri
 - **History**: 5000 lines
 - **Copy/Paste**: Ctrl-C/Ctrl-V for clipboard operations
 
+### Ghostty Configuration
+
+Modern GPU-accelerated terminal emulator with native multiplexing (alternative to tmux):
+
+- **Default Shell**: Zsh with native shell integration
+- **Mouse Support**: Enabled with native clipboard integration
+- **Key Bindings**:
+  - `Ctrl+Shift+V`: Split vertically (down)
+  - `Ctrl+Shift+H`: Split horizontally (right)
+  - `Shift+Arrow`: Navigate between splits
+  - `Ctrl+T`: Next tab
+  - `Ctrl+Shift+T`: New tab
+  - `Ctrl+Shift+C`: Copy to clipboard
+  - `Ctrl+Shift+V`: Paste from clipboard
+  - `Ctrl+Shift+R`: Reload configuration
+- **Scrollback**: 5000 lines
+- **Terminal**: 256 color support (xterm-256color)
+- **Features**: GPU-accelerated rendering, native split panes, session management
+
 ## Requirements
 
 ### Core Dependencies
@@ -62,8 +82,9 @@ Personal configuration files for macOS, optimized for DevOps and cloud engineeri
 
 ### Recommended Packages
 ```bash
-# Terminal multiplexer and utilities
-brew install tmux
+# Terminal emulator and multiplexer
+brew install ghostty              # Modern GPU-accelerated terminal (tmux alternative)
+brew install tmux                 # Traditional terminal multiplexer
 brew install peco
 brew install reattach-to-user-namespace
 
@@ -119,6 +140,10 @@ mv ~/.tmux.conf ~/.tmux.conf.backup
 ```bash
 ln -s ~/dotfiles/.zshrc ~/.zshrc
 ln -s ~/dotfiles/.tmux.conf ~/.tmux.conf
+
+# For Ghostty configuration
+mkdir -p ~/.config/ghostty
+ln -sf ~/dotfiles/ghostty/config ~/.config/ghostty/config
 ```
 
 4. Install Oh My Zsh (if not already installed):
@@ -173,6 +198,40 @@ source ~/.zshrc
 - `Ctrl-T h`: Horizontal split
 - `Shift+Arrow`: Navigate between panes
 
+### Ghostty Usage
+
+**Getting Started:**
+- Launch Ghostty from Applications or via `ghostty` command
+- Configuration loads automatically from `~/.config/ghostty/config`
+
+**Split Management:**
+- `Ctrl+Shift+V`: Create vertical split (split down)
+- `Ctrl+Shift+H`: Create horizontal split (split right)
+- `Shift+Arrow Keys`: Navigate between splits
+- Mouse click to focus a split
+
+**Tab Management:**
+- `Ctrl+T`: Switch to next tab
+- `Ctrl+Shift+T`: Create new tab
+- Mouse click on tab bar to switch tabs
+
+**Clipboard Operations:**
+- `Ctrl+Shift+C`: Copy selected text to clipboard
+- `Ctrl+Shift+V`: Paste from clipboard
+- Native macOS clipboard integration (no reattach-to-user-namespace needed)
+
+**Configuration:**
+- `Ctrl+Shift+R`: Reload configuration without restarting
+- Edit `~/dotfiles/ghostty/config` to customize settings
+- Changes take effect immediately after reload
+
+**Benefits over tmux:**
+- GPU-accelerated rendering for better performance
+- Native split panes without separate multiplexer process
+- Direct clipboard integration without additional tools
+- Modern UI with mouse support out of the box
+- Session persistence built-in
+
 ## Configuration Details
 
 ### Environment Variables
@@ -209,6 +268,11 @@ Feel free to fork and customize these configurations for your own needs:
 - Modify the theme in `.zshrc` by changing `ZSH_THEME`
 - Add/remove Oh My Zsh plugins in the `plugins` array
 - Adjust tmux prefix key in `.tmux.conf`
+- Customize Ghostty appearance and behavior in `ghostty/config`:
+  - Change `font-family` and `font-size` for different fonts
+  - Modify `theme` for different color schemes
+  - Adjust keybindings to match your workflow
+  - Configure `background-opacity` for transparency effects
 - Add your own aliases and functions to `.zshrc`
 - Update Python version in `CLOUDSDK_PYTHON` if using different Python version
 

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,85 @@
+# Ghostty Terminal Configuration
+# Replacing tmux with Ghostty's native features
+# Based on .tmux.conf configuration
+
+# Shell Configuration
+# Set zsh as default shell (equivalent to tmux's default-shell)
+shell-integration = zsh
+command = /bin/zsh
+
+# Window and Tab Settings
+# Ghostty uses tabs similar to tmux windows
+window-decoration = true
+window-theme = auto
+
+# Theme and Colors
+# 256 color support (equivalent to tmux's xterm-256color)
+theme = default
+background-opacity = 1.0
+
+# Mouse Support
+# Enable mouse support (equivalent to tmux's mouse on)
+mouse-hide-while-typing = false
+
+# Clipboard Integration
+# Ghostty has native clipboard support (no need for reattach-to-user-namespace)
+clipboard-read = allow
+clipboard-write = allow
+clipboard-trim-trailing-spaces = true
+
+# Scrollback Configuration
+# History limit (equivalent to tmux's history-limit 5000)
+scrollback-limit = 5000
+
+# Keybindings
+# Ghostty uses different keybinding syntax than tmux
+# Split panes: vertical and horizontal
+keybind = ctrl+shift+v=new_split:down
+keybind = ctrl+shift+h=new_split:right
+
+# Navigate between splits with Shift+Arrow keys
+keybind = shift+left=goto_split:left
+keybind = shift+down=goto_split:bottom
+keybind = shift+up=goto_split:top
+keybind = shift+right=goto_split:right
+
+# Tab/Window navigation (equivalent to tmux's C-t next-window)
+keybind = ctrl+t=next_tab
+keybind = ctrl+shift+t=new_tab
+
+# Copy mode keybindings
+keybind = ctrl+shift+c=copy_to_clipboard
+keybind = ctrl+shift+v=paste_from_clipboard
+
+# Reload configuration (equivalent to tmux's prefix+r)
+keybind = ctrl+shift+r=reload_config
+
+# Font Configuration
+# Adjust these to your preference
+font-family = "Monaco"
+font-size = 12
+font-feature = -calt
+font-feature = -liga
+
+# Performance
+# Optimize rendering performance
+term = xterm-256color
+
+# Window Padding
+window-padding-x = 4
+window-padding-y = 4
+
+# Tab Bar Configuration
+# Similar to tmux status bar
+window-step-resize = true
+gtk-titlebar = false
+
+# Additional Settings
+# Auto-update check
+auto-update = check
+
+# Confirm before closing windows with running processes
+confirm-close-surface = true
+
+# Working directory
+working-directory = inherit


### PR DESCRIPTION
- Create ghostty directory and config file
- Translate tmux configuration to Ghostty equivalents
- Configure split panes with keybindings (Ctrl+Shift+V/H)
- Enable split navigation with Shift+Arrow keys
- Set zsh as default shell with native integration
- Configure 5000 line scrollback buffer
- Enable mouse support and clipboard integration
- Set 256 color terminal support

This configuration replaces tmux with Ghostty's native terminal multiplexing features while preserving similar workflow.