### PR TITLE
Update Ghostty keybindings to use Ctrl+Y prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,26 @@ Modern GPU-accelerated terminal emulator with native multiplexing (alternative t
 
 - **Default Shell**: Zsh with native shell integration
 - **Mouse Support**: Enabled with native clipboard integration
-- **Key Bindings**:
-  - `Ctrl+Shift+V`: Split vertically (down)
-  - `Ctrl+Shift+H`: Split horizontally (right)
-  - `Shift+Arrow`: Navigate between splits
-  - `Ctrl+T`: Next tab
-  - `Ctrl+Shift+T`: New tab
-  - `Ctrl+Shift+C`: Copy to clipboard
-  - `Ctrl+Shift+V`: Paste from clipboard
-  - `Ctrl+Shift+R`: Reload configuration
+- **Prefix Key**: `Ctrl+T` (matching tmux configuration)
+- **Key Bindings** (chord-based like tmux):
+  - **Split Management**:
+    - `Ctrl+T > H`: Split left
+    - `Ctrl+T > J`: Split down
+    - `Ctrl+T > K`: Split up
+    - `Ctrl+T > L`: Split right
+    - `Ctrl+T > F`: Toggle split zoom (maximize/restore)
+  - **Navigation**:
+    - `Ctrl+T > Arrow Keys`: Navigate between splits
+    - `Ctrl+T > H/J/K/L`: Vim-style split navigation
+  - **Tab Management**:
+    - `Ctrl+T > N`: Next tab
+    - `Ctrl+T > P`: Previous tab
+    - `Ctrl+T > C`: Create new tab
+  - **Clipboard**:
+    - `Ctrl+T > Shift+C`: Copy to clipboard
+    - `Ctrl+T > V`: Paste from clipboard
+  - **Configuration**:
+    - `Ctrl+T > R`: Reload configuration
 - **Scrollback**: 5000 lines
 - **Terminal**: 256 color support (xterm-256color)
 - **Features**: GPU-accelerated rendering, native split panes, session management
@@ -204,26 +215,29 @@ source ~/.zshrc
 - Launch Ghostty from Applications or via `ghostty` command
 - Configuration loads automatically from `~/.config/ghostty/config`
 
-**Split Management:**
-- `Ctrl+Shift+V`: Create vertical split (split down)
-- `Ctrl+Shift+H`: Create horizontal split (split right)
-- `Shift+Arrow Keys`: Navigate between splits
+**Split Management (tmux-style prefix):**
+- `Ctrl+T > H/J/K/L`: Create splits left/down/up/right (vim-style)
+- `Ctrl+T > Arrow Keys`: Navigate between splits
+- `Ctrl+T > F`: Toggle split zoom (maximize/restore current split)
 - Mouse click to focus a split
 
 **Tab Management:**
-- `Ctrl+T`: Switch to next tab
-- `Ctrl+Shift+T`: Create new tab
+- `Ctrl+T > N`: Switch to next tab
+- `Ctrl+T > P`: Switch to previous tab
+- `Ctrl+T > C`: Create new tab
 - Mouse click on tab bar to switch tabs
 
 **Clipboard Operations:**
-- `Ctrl+Shift+C`: Copy selected text to clipboard
-- `Ctrl+Shift+V`: Paste from clipboard
+- `Ctrl+T > Shift+C`: Copy selected text to clipboard
+- `Ctrl+T > V`: Paste from clipboard
 - Native macOS clipboard integration (no reattach-to-user-namespace needed)
 
 **Configuration:**
-- `Ctrl+Shift+R`: Reload configuration without restarting
+- `Ctrl+T > R`: Reload configuration without restarting
 - Edit `~/dotfiles/ghostty/config` to customize settings
 - Changes take effect immediately after reload
+
+**Note:** The `>` symbol indicates a chord sequence - press `Ctrl+T`, release, then press the next key (similar to tmux prefix behavior)
 
 **Benefits over tmux:**
 - GPU-accelerated rendering for better performance

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Modern GPU-accelerated terminal emulator with native multiplexing (alternative t
     - `Ctrl+T > L`: Split right
     - `Ctrl+T > F`: Toggle split zoom (maximize/restore)
   - **Navigation**:
-    - `Ctrl+T > Arrow Keys`: Navigate between splits
+    - `Shift+Arrow Keys`: Quick navigation between splits
+    - `Ctrl+T > Arrow Keys`: Navigate between splits (prefix style)
     - `Ctrl+T > H/J/K/L`: Vim-style split navigation
   - **Tab Management**:
     - `Ctrl+T > N`: Next tab
@@ -215,9 +216,10 @@ source ~/.zshrc
 - Launch Ghostty from Applications or via `ghostty` command
 - Configuration loads automatically from `~/.config/ghostty/config`
 
-**Split Management (tmux-style prefix):**
+**Split Management:**
 - `Ctrl+T > H/J/K/L`: Create splits left/down/up/right (vim-style)
-- `Ctrl+T > Arrow Keys`: Navigate between splits
+- `Shift+Arrow Keys`: Quick navigation between splits
+- `Ctrl+T > Arrow Keys`: Navigate between splits (prefix style)
 - `Ctrl+T > F`: Toggle split zoom (maximize/restore current split)
 - Mouse click to focus a split
 

--- a/ghostty/config
+++ b/ghostty/config
@@ -32,33 +32,33 @@ clipboard-trim-trailing-spaces = true
 scrollback-limit = 5000
 
 # Keybindings
-# Using ctrl+y as the primary modifier (matching tmux prefix)
+# Using ctrl+t as the primary modifier (matching tmux prefix)
 # Split panes: vertical and horizontal (h/v split down/right, j/k/l/h navigation)
-keybind = ctrl+y>h=new_split:left
-keybind = ctrl+y>j=new_split:down
-keybind = ctrl+y>k=new_split:up
-keybind = ctrl+y>l=new_split:right
+keybind = ctrl+t>h=new_split:left
+keybind = ctrl+t>j=new_split:down
+keybind = ctrl+t>k=new_split:up
+keybind = ctrl+t>l=new_split:right
 
-# Navigate between splits with ctrl+y and arrow keys
-keybind = ctrl+y>left=goto_split:left
-keybind = ctrl+y>down=goto_split:bottom
-keybind = ctrl+y>up=goto_split:top
-keybind = ctrl+y>right=goto_split:right
+# Navigate between splits with ctrl+t and arrow keys
+keybind = ctrl+t>left=goto_split:left
+keybind = ctrl+t>down=goto_split:bottom
+keybind = ctrl+t>up=goto_split:top
+keybind = ctrl+t>right=goto_split:right
 
 # Toggle split zoom
-keybind = ctrl+y>f=toggle_split_zoom
+keybind = ctrl+t>f=toggle_split_zoom
 
 # Tab/Window navigation (similar to tmux window commands)
-keybind = ctrl+y>n=next_tab
-keybind = ctrl+y>p=previous_tab
-keybind = ctrl+y>c=new_tab
+keybind = ctrl+t>n=next_tab
+keybind = ctrl+t>p=previous_tab
+keybind = ctrl+t>c=new_tab
 
 # Copy mode keybindings
-keybind = ctrl+y>shift+c=copy_to_clipboard
-keybind = ctrl+y>v=paste_from_clipboard
+keybind = ctrl+t>shift+c=copy_to_clipboard
+keybind = ctrl+t>v=paste_from_clipboard
 
 # Reload configuration (equivalent to tmux's prefix+r)
-keybind = ctrl+y>r=reload_config
+keybind = ctrl+t>r=reload_config
 
 # Font Configuration
 # Adjust these to your preference

--- a/ghostty/config
+++ b/ghostty/config
@@ -45,6 +45,12 @@ keybind = ctrl+t>down=goto_split:bottom
 keybind = ctrl+t>up=goto_split:top
 keybind = ctrl+t>right=goto_split:right
 
+# Navigate between splits with Shift+Arrow keys
+keybind = shift+left=goto_split:left
+keybind = shift+down=goto_split:bottom
+keybind = shift+up=goto_split:top
+keybind = shift+right=goto_split:right
+
 # Toggle split zoom
 keybind = ctrl+t>f=toggle_split_zoom
 

--- a/ghostty/config
+++ b/ghostty/config
@@ -33,26 +33,32 @@ scrollback-limit = 5000
 
 # Keybindings
 # Using ctrl+y as the primary modifier (matching tmux prefix)
-# Split panes: vertical and horizontal
-keybind = ctrl+y+v=new_split:down
-keybind = ctrl+y+h=new_split:right
+# Split panes: vertical and horizontal (h/v split down/right, j/k/l/h navigation)
+keybind = ctrl+y>h=new_split:left
+keybind = ctrl+y>j=new_split:down
+keybind = ctrl+y>k=new_split:up
+keybind = ctrl+y>l=new_split:right
 
-# Navigate between splits with ctrl+y+arrow keys
-keybind = ctrl+y+left=goto_split:left
-keybind = ctrl+y+down=goto_split:bottom
-keybind = ctrl+y+up=goto_split:top
-keybind = ctrl+y+right=goto_split:right
+# Navigate between splits with ctrl+y and arrow keys
+keybind = ctrl+y>left=goto_split:left
+keybind = ctrl+y>down=goto_split:bottom
+keybind = ctrl+y>up=goto_split:top
+keybind = ctrl+y>right=goto_split:right
+
+# Toggle split zoom
+keybind = ctrl+y>f=toggle_split_zoom
 
 # Tab/Window navigation (similar to tmux window commands)
-keybind = ctrl+y+n=next_tab
-keybind = ctrl+y+c=new_tab
+keybind = ctrl+y>n=next_tab
+keybind = ctrl+y>p=previous_tab
+keybind = ctrl+y>c=new_tab
 
 # Copy mode keybindings
-keybind = ctrl+y+shift+c=copy_to_clipboard
-keybind = ctrl+y+p=paste_from_clipboard
+keybind = ctrl+y>shift+c=copy_to_clipboard
+keybind = ctrl+y>v=paste_from_clipboard
 
 # Reload configuration (equivalent to tmux's prefix+r)
-keybind = ctrl+y+r=reload_config
+keybind = ctrl+y>r=reload_config
 
 # Font Configuration
 # Adjust these to your preference

--- a/ghostty/config
+++ b/ghostty/config
@@ -32,27 +32,27 @@ clipboard-trim-trailing-spaces = true
 scrollback-limit = 5000
 
 # Keybindings
-# Ghostty uses different keybinding syntax than tmux
+# Using ctrl+y as the primary modifier (matching tmux prefix)
 # Split panes: vertical and horizontal
-keybind = ctrl+shift+v=new_split:down
-keybind = ctrl+shift+h=new_split:right
+keybind = ctrl+y+v=new_split:down
+keybind = ctrl+y+h=new_split:right
 
-# Navigate between splits with Shift+Arrow keys
-keybind = shift+left=goto_split:left
-keybind = shift+down=goto_split:bottom
-keybind = shift+up=goto_split:top
-keybind = shift+right=goto_split:right
+# Navigate between splits with ctrl+y+arrow keys
+keybind = ctrl+y+left=goto_split:left
+keybind = ctrl+y+down=goto_split:bottom
+keybind = ctrl+y+up=goto_split:top
+keybind = ctrl+y+right=goto_split:right
 
-# Tab/Window navigation (equivalent to tmux's C-t next-window)
-keybind = ctrl+t=next_tab
-keybind = ctrl+shift+t=new_tab
+# Tab/Window navigation (similar to tmux window commands)
+keybind = ctrl+y+n=next_tab
+keybind = ctrl+y+c=new_tab
 
 # Copy mode keybindings
-keybind = ctrl+shift+c=copy_to_clipboard
-keybind = ctrl+shift+v=paste_from_clipboard
+keybind = ctrl+y+shift+c=copy_to_clipboard
+keybind = ctrl+y+p=paste_from_clipboard
 
 # Reload configuration (equivalent to tmux's prefix+r)
-keybind = ctrl+shift+r=reload_config
+keybind = ctrl+y+r=reload_config
 
 # Font Configuration
 # Adjust these to your preference


### PR DESCRIPTION
- Replace ctrl+shift combinations with ctrl+y based bindings
- Align keybindings with tmux muscle memory (ctrl+y prefix)
- Update split commands: ctrl+y+v (down), ctrl+y+h (right)
- Update navigation: ctrl+y+arrow keys
- Update tab commands: ctrl+y+n (next), ctrl+y+c (create)
- Update copy/paste: ctrl+y+shift+c, ctrl+y+p
- Fix duplicate keybind conflict (ctrl+shift+v was used twice)