### PR TITLE
feat(ghostty): add emacs-mode keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Modern GPU-accelerated terminal emulator with native multiplexing (alternative t
     - `Ctrl+T > V`: Paste from clipboard
   - **Configuration**:
     - `Ctrl+T > R`: Reload configuration
+  - **Emacs Mode** (press `Alt+E` to activate):
+    - `Ctrl+N/P`: Scroll line down/up
+    - `Ctrl+V`: Page down
+    - `Alt+V`: Page up
+    - `Alt+<` / `Alt+>`: Jump to top/bottom
+    - `Ctrl+S`: Start search
+    - `Ctrl+R`: Previous search result
+    - `Alt+W`: Copy to clipboard
+    - `Alt+X`: Command palette
+    - `Ctrl+G` or `Escape`: Exit emacs mode
 - **Scrollback**: 5000 lines
 - **Terminal**: 256 color support (xterm-256color)
 - **Features**: GPU-accelerated rendering, native split panes, session management

--- a/ghostty/config
+++ b/ghostty/config
@@ -116,6 +116,49 @@ keybind = ctrl+t>v=paste_from_clipboard
 # Reload configuration (equivalent to tmux's prefix+r)
 keybind = ctrl+t>r=reload_config
 
+# Emacs-mode keybindings for Ghostty.
+#
+# Modeled after mitchellh's vim-mode keybindings.
+# https://gist.github.com/mitchellh/1c5be5c083a2315f22f1cb8f239e9dcd
+#
+# Note: Some emacs actions are not yet available in Ghostty's keybinding system.
+# This implements what is possible today.
+
+# Entry point (Alt+E to enter emacs mode)
+keybind = alt+e=activate_key_table:emacs
+
+# Key table definition
+keybind = emacs/
+
+# Line movement (C-n/C-p)
+keybind = emacs/ctrl+n=scroll_page_lines:1
+keybind = emacs/ctrl+p=scroll_page_lines:-1
+
+# Page movement (C-v/M-v)
+keybind = emacs/ctrl+v=scroll_page_down
+keybind = emacs/alt+v=scroll_page_up
+
+# Jump to top/bottom (M-</M->)
+keybind = emacs/alt+shift+comma=scroll_to_top
+keybind = emacs/alt+shift+period=scroll_to_bottom
+
+# Search (C-s forward, C-r reverse)
+keybind = emacs/ctrl+s=start_search
+keybind = emacs/ctrl+r=navigate_search:previous
+
+# Copy (M-w kill-ring-save)
+keybind = emacs/alt+w=copy_to_clipboard
+
+# Command Palette (M-x execute-extended-command)
+keybind = emacs/alt+x=toggle_command_palette
+
+# Exit (C-g keyboard-quit)
+keybind = emacs/ctrl+g=deactivate_key_table
+keybind = emacs/escape=deactivate_key_table
+
+# Catch unbound keys
+keybind = emacs/catch_all=ignore
+
 # Font Configuration
 # Adjust these to your preference
 font-family = "Monaco"


### PR DESCRIPTION
## Summary

- Add emacs-mode keybindings for Ghostty scrollback navigation
- Modeled after [mitchellh's vim-mode gist](https://gist.github.com/mitchellh/1c5be5c083a2315f22f1cb8f239e9dcd)
- Activate with `Alt+E`, exit with `C-g` or `Escape`

## Keybindings

| Emacs Key | Action |
|-----------|--------|
| `C-n` / `C-p` | Scroll line down/up |
| `C-v` / `M-v` | Page down/up |
| `M-<` / `M->` | Jump to top/bottom |
| `C-s` | Start search |
| `C-r` | Previous search result |
| `M-w` | Copy to clipboard |
| `M-x` | Command palette |
| `C-g` / `Escape` | Exit emacs mode |

## Test plan

- [ ] Press `Alt+E` to enter emacs mode
- [ ] Test `C-n`/`C-p` for line scrolling
- [ ] Test `C-v`/`M-v` for page scrolling
- [ ] Test `M-<`/`M->` for jump to top/bottom
- [ ] Test `C-s` to start search
- [ ] Test `M-w` for copy
- [ ] Test `M-x` for command palette
- [ ] Test `C-g` or `Escape` to exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)